### PR TITLE
Agregar request de categorías de formacion general

### DIFF
--- a/app.py
+++ b/app.py
@@ -71,7 +71,7 @@ def index():
 
 
 @app.route("/api/v1", methods=["GET"])
-def BC_API_get(vacantes=False, formato=False, formacion_general=False):
+def BC_API_get(vacantes=False, formato=False):
     """ HTTP GET method for v1
     Args:
         vancante (bool): Allow the use of 'vacantes' parameters in the request.
@@ -84,7 +84,7 @@ def BC_API_get(vacantes=False, formato=False, formacion_general=False):
     """
     arguments = request.args
     parameters, bad_arguments = check_arguments(
-        arguments, vacantes, formato, formacion_general)
+        arguments, vacantes, formato)
 
     if not arguments:
         return response(400, {"message": "(#400) Requests with no arguments."})
@@ -201,7 +201,7 @@ def BC_API_v3_get():
             }
         )
 
-    resp, code = BC_API_get(vac, form, True)
+    resp, code = BC_API_get(vac, form)
 
     if "vacantes" in request.args and code == 200 and vac:
         resp["data"] = manage_vacancies(resp["data"])

--- a/app.py
+++ b/app.py
@@ -11,10 +11,6 @@ app.config["JSON_AS_ASCII"] = False
 cors = CORS(app, resources={r"/api/*": {"origins": "*"}})
 
 
-with open("info_buscacursos.json", "r") as file:
-    INFO = json.load(file)
-
-
 def response(code: int, data: dict = None):
     """ Create the response for any request based on the status code.
 

--- a/endpoints_functions.py
+++ b/endpoints_functions.py
@@ -22,7 +22,7 @@ with open("info_buscacursos.json", "r") as file:
     INFO = json.load(file)
 
 
-def check_arguments(arguments, vacantes, formato, formacion_general):
+def check_arguments(arguments, vacantes, formato):
     parameters = {
         "cxml_semestre": "2022-1",
         "cxml_sigla": "",
@@ -32,6 +32,7 @@ def check_arguments(arguments, vacantes, formato, formacion_general):
         "cxml_categoria": "TODOS",
         "cxml_campus": "TODOS",
         "cxml_unidad_academica": "TODOS",
+        "cxml_area_fg": "TODOS"
     }
 
     bad_arguments = []
@@ -48,11 +49,6 @@ def check_arguments(arguments, vacantes, formato, formacion_general):
             if not formato:
                 bad_arguments.append(a)
             parameters[KEY_CONVERSOR[a]] = "TODOS"
-            continue
-        elif a == "formacion_general":
-            if not formacion_general:
-                bad_arguments.append(a)
-            parameters[KEY_CONVERSOR[a]] = INFO["formacion_general"][arguments[a]]
             continue
 
         parameters[KEY_CONVERSOR[a]] = arguments[a]

--- a/endpoints_functions.py
+++ b/endpoints_functions.py
@@ -24,7 +24,7 @@ with open("info_buscacursos.json", "r") as file:
 
 def check_arguments(arguments, vacantes, formato, formacion_general):
     parameters = {
-        "cxml_semestre": "2021-2",
+        "cxml_semestre": "2022-1",
         "cxml_sigla": "",
         "cxml_nrc": "",
         "cxml_nombre": "",

--- a/endpoints_functions.py
+++ b/endpoints_functions.py
@@ -1,4 +1,5 @@
 from Requests import request_vacancy, request_requirements
+import json
 
 
 KEY_CONVERSOR = {
@@ -15,6 +16,10 @@ KEY_CONVERSOR = {
     "formato": "cxml_formato_cur",
     "formacion_general": "cxml_area_fg"
 }
+
+
+with open("info_buscacursos.json", "r") as file:
+    INFO = json.load(file)
 
 
 def check_arguments(arguments, vacantes, formato, formacion_general):
@@ -47,7 +52,7 @@ def check_arguments(arguments, vacantes, formato, formacion_general):
         elif a == "formacion_general":
             if not formacion_general:
                 bad_arguments.append(a)
-            parameters[KEY_CONVERSOR[a]] = "TODOS"
+            parameters[KEY_CONVERSOR[a]] = INFO["formacion_general"][arguments[a]]
             continue
 
         parameters[KEY_CONVERSOR[a]] = arguments[a]

--- a/endpoints_functions.py
+++ b/endpoints_functions.py
@@ -1,5 +1,4 @@
 from Requests import request_vacancy, request_requirements
-import json
 
 
 KEY_CONVERSOR = {
@@ -16,10 +15,6 @@ KEY_CONVERSOR = {
     "formato": "cxml_formato_cur",
     "formacion_general": "cxml_area_fg"
 }
-
-
-with open("info_buscacursos.json", "r") as file:
-    INFO = json.load(file)
 
 
 def check_arguments(arguments, vacantes, formato):


### PR DESCRIPTION
Hola Ian!!

Espero que estés súper 🤩

Agregué una cosita chica a la API, ahora se pueden filtrar los cursos por categoría de formación general. Desde este año se empieza a aplicar la [nueva estructura del plan de Formación General](https://formaciongeneral.uc.cl/como-funciona-la-formacion-general/) para las nuevas generaciones de Ingeniería. Básicamente, desde ahora en adelante los estudiantes deben seleccionar sus OFGs según la categoría en la que se encuentran.

Como Consejería Académica queremos hacer una pequeña aplicación web para ayudar en la selección de cursos de formación general, tanto para la generación 2022 como los más viejos, y nos serviría mucho usar esta API con el cambio que necesita la generación novata 😊 Si quieres conversar de eso feliz!!

(También, actualicé el semestre ✨)